### PR TITLE
Improved error message formatting when host has not been specified

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -95,7 +95,7 @@ function createCrawlerConfig($initialUrl)
     $urlParts = parse_url($initialUrl);
     if (array_key_exists('host', $urlParts) === false) {
         echo "Could not determine domain name from " . $initialUrl . "\n";
-        echo "Please include the schema like http://example.com";
+        echo "Please include the schema like http://example.com \n";
         exit(-1);
     }
 


### PR DESCRIPTION
Added a newline to the error message output (when a host was not specified).

**Before:**
![1](https://user-images.githubusercontent.com/14973705/32167287-24e0237e-bd71-11e7-9f15-471db3f21acf.png)

**After:**
![screenshot from 2017-10-30 12-36-22](https://user-images.githubusercontent.com/14973705/32167297-2b6994fa-bd71-11e7-95bc-b847e15ab3b8.png)

