### PR TITLE
Fix case-insensitive use statement

### DIFF
--- a/src/SiteTool/Command/Crawler.php
+++ b/src/SiteTool/Command/Crawler.php
@@ -4,7 +4,7 @@ namespace SiteTool\Command;
 
 use Auryn\Injector;
 use SiteTool\CrawlerConfig;
-use SiteTool\URLToCheck;
+use SiteTool\UrlToCheck;
 use SiteTool\Writer\OutputWriter;
 use SiteTool\Processor\CheckContentTypeIsHtml;
 use SiteTool\Processor\FetchUrl;
@@ -53,7 +53,7 @@ class Crawler
             return;
         }
         
-        $firstUrlToCheck = new URLToCheck('http://' . $crawlerConfig->domainName . $crawlerConfig->path, '/');
+        $firstUrlToCheck = new UrlToCheck('http://' . $crawlerConfig->domainName . $crawlerConfig->path, '/');
         $foundUrlToFollow = new FoundUrlToFollow($firstUrlToCheck);
         $eventManager->trigger(FoundUrlToFollow::class, null, [$foundUrlToFollow]);
         $outputWriter->write(OutputWriter::PROGRESS, "Start.");


### PR DESCRIPTION
Fixed case-insensitive ```use``` satement for ```UrlToCheck``` class, that was causing ```Uncaught Error: Class 'SiteTool\URLToCheck' not found``` error on Ubuntu